### PR TITLE
fix not adding first message to controller

### DIFF
--- a/lib/src/impl/relay_impl.dart
+++ b/lib/src/impl/relay_impl.dart
@@ -43,10 +43,8 @@ class Relay implements RelayApi {
           // If this is the first event after connecting to the server, set the _connected flag to true and call the onEvent callback with the RelayEvent.connect event
           _connected = true;
           onEvent?.call(RelayEvent.connect);
-        } else {
-          // Otherwise, add the event message to the stream controller
-          controller.add(message);
         }
+        controller.add(message);
       },
       onError: (error) {
         // If there is an error with the WebSocket channel, add the error to the stream controller

--- a/lib/src/impl/relay_pool_impl.dart
+++ b/lib/src/impl/relay_pool_impl.dart
@@ -40,7 +40,8 @@ class RelayPool implements RelayPoolApi {
                 relayUrl,
               ); // remove from failed relays set if previously failed
               onEvent?.call(RelayEvent.connect);
-            } else if (id != null && !_receivedMessageIds.contains(id)) {
+            }
+            if (id != null && !_receivedMessageIds.contains(id)) {
               _receivedMessageIds.add(id);
               controller.add(message);
             }


### PR DESCRIPTION
In both relay_impl and relay_pool_impl there is a bug which skips the first message in order to call RelayEvent.connect.
You can reproduce this easily if you sub with a Filter with your pubKey as authors and kinds [3] (Contact List), it will simple not add anything to the controller, since there is only 1 event returned.

You can test what it should return on https://www.piesocket.com/websocket-tester.
Using for example wss://relay.damus.io and sending:

`["REQ","41a95c31de26671202d7971c0c3e58c9a40afd761dd2e663fb1a54da5f57aaa3",{"authors":["30782a8323b7c98b172c5a2af7206bb8283c655be6ddce11133611a03d5f1177"],"kinds":[3]}]`

I fixed this, by always calling `controller.add(message)` (removing the else) in both relay_impl and relay_pool_impl.
